### PR TITLE
Readonly attribute

### DIFF
--- a/src/js/directives/bsdate.js
+++ b/src/js/directives/bsdate.js
@@ -17,7 +17,8 @@ angular.module('xeditable').directive('editableBsdate', ['editableDirectiveFacto
 				var inputDatePicker = angular.element('<input type="text" class="form-control" ng-model="$data"/>');
 				var buttonDatePicker = angular.element('<button type="button" class="btn btn-default"><i class="glyphicon glyphicon-calendar"></i></button>');
 				var buttonWrapper = angular.element('<span class="input-group-btn"></span>');
-
+				
+				inputDatePicker.attr('ng-readonly', this.attrs.eReadonly || false);	
 				inputDatePicker.attr('datepicker-popup', this.attrs.eDatepickerPopupXEditable || 'yyyy/MM/dd' );
 				inputDatePicker.attr('is-open', this.attrs.eIsOpen);
 				inputDatePicker.attr('date-disabled', this.attrs.eDateDisabled);


### PR DESCRIPTION
adds the option e-readonly="true/false" - defaults to false to the date input (allowing to stop the user from editing the field and only using the datepicker)
